### PR TITLE
feat: add support for custom initializationOptions and originalRootUri

### DIFF
--- a/src/features/definition.ts
+++ b/src/features/definition.ts
@@ -15,7 +15,7 @@ export const definitionFeature: Feature<typeof DefinitionRequest.type, 'definiti
                         DefinitionRequest.type,
                         convertProviderParams({ textDocument, position }, { clientToServerURI })
                     )
-                    rewriteUris(result, serverToClientURI)
+                    rewriteUris(result, uri => serverToClientURI(uri, scopeRootUri))
                     return convertLocations(sourcegraph, result as Location | Location[] | null)
                 },
             }

--- a/src/features/feature.ts
+++ b/src/features/feature.ts
@@ -14,7 +14,7 @@ export interface Feature<R extends RequestType<any, any, any, any>, C extends ke
         sourcegraph: typeof import('sourcegraph')
         scopeRootUri: URL | null
         clientToServerURI: (uri: URL) => URL
-        serverToClientURI: (uri: URL) => URL
+        serverToClientURI: (uri: URL, scopeRootUri: URL | null) => URL
         registerOptions: RegistrationOptions<R>
     }): Unsubscribable
 }

--- a/src/features/hover.ts
+++ b/src/features/hover.ts
@@ -15,7 +15,7 @@ export const hoverFeature: Feature<typeof HoverRequest.type, 'hoverProvider'> = 
                         HoverRequest.type,
                         convertProviderParams({ textDocument, position }, { clientToServerURI })
                     )
-                    rewriteUris(result, serverToClientURI)
+                    rewriteUris(result, uri => serverToClientURI(uri, scopeRootUri))
                     return convertHover(sourcegraph, result)
                 },
             }

--- a/src/features/references.ts
+++ b/src/features/references.ts
@@ -15,7 +15,7 @@ export const referencesFeature: Feature<typeof ReferencesRequest.type, 'referenc
                         ...convertProviderParams({ textDocument, position }, { clientToServerURI }),
                         context,
                     })
-                    rewriteUris(result, serverToClientURI)
+                    rewriteUris(result, uri => serverToClientURI(uri, scopeRootUri))
                     return convertLocations(sourcegraph, result)
                 },
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ export async function register({
 
     async function connect(
         clientRootUri: URL | null,
-        initParams: InitializeParams & { originalRootUri?: string | null }
+        initParams: InitializeParams
     ): Promise<LSPConnection> {
         const subscriptions = new Subscription()
         const decorationType = sourcegraph.app.createDecorationType()
@@ -302,7 +302,6 @@ export async function register({
                 rootUri: null,
                 capabilities: clientCapabilities,
                 workspaceFolders: sourcegraph.workspace.roots.map(toLSPWorkspaceFolder({ clientToServerURI })),
-                originalRootUri: null,
                 initializationOptions: additionalInitializationOptions,
             }
         )
@@ -371,7 +370,6 @@ export async function register({
                 {
                     processId: null,
                     rootUri: serverRootUri.href,
-                    originalRootUri: workspaceFolder.href,
                     capabilities: clientCapabilities,
                     workspaceFolders: null,
                     initializationOptions: additionalInitializationOptions,
@@ -394,7 +392,6 @@ export async function register({
                             new URL(root.uri.toString()),
                             {
                                 processId: null,
-                                originalRootUri: root.uri.toString(),
                                 rootUri: serverRootUri.href,
                                 capabilities: clientCapabilities,
                                 workspaceFolders: null,


### PR DESCRIPTION
This is a total hack, but actually helps sourcegraph-go activate and initiate a connection with go-langserver. See https://github.com/sourcegraph/sourcegraph-go/issues/28