### PR TITLE
fix: do not register providers inside of withConnection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,11 +158,11 @@ export async function register({
     async function connect({
         clientRootUri,
         initParams,
-        registerProviders = false,
+        registerProviders,
     }: {
         clientRootUri: URL | null
         initParams: InitializeParams
-        registerProviders?: boolean
+        registerProviders: boolean
     }): Promise<LSPConnection> {
         const subscriptions = new Subscription()
         const decorationType = sourcegraph.app.createDecorationType()
@@ -388,6 +388,7 @@ export async function register({
                     workspaceFolders: null,
                     initializationOptions,
                 },
+                registerProviders: false
             })
             subscriptions.add(connection)
             try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,7 @@ export async function register({
                 workspaceFolders: sourcegraph.workspace.roots.map(toLSPWorkspaceFolder({ clientToServerURI })),
                 initializationOptions,
             },
-            registerProviders: true
+            registerProviders: true,
         })
         subscriptions.add(connection)
         withConnection = async (workspaceFolder, fn) => {
@@ -388,7 +388,7 @@ export async function register({
                     workspaceFolders: null,
                     initializationOptions,
                 },
-                registerProviders: false
+                registerProviders: false,
             })
             subscriptions.add(connection)
             try {
@@ -412,7 +412,7 @@ export async function register({
                                 workspaceFolders: null,
                                 initializationOptions,
                             },
-                            registerProviders: true
+                            registerProviders: true,
                         })
                         subscriptions.add(connection)
                         return connection

--- a/yarn.lock
+++ b/yarn.lock
@@ -5555,7 +5555,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcegraph@^23.0.1, sourcegraph@^23.1.0:
+sourcegraph@^23.1.0:
   version "23.1.0"
   resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-23.1.0.tgz#3178979805239cdf777d7b2cb9aae99c2a3d1dcb"
   integrity sha512-pcHP/Ad1TGJWDu4vh8iDE1bi4LOvDgc2Q+amlByjSfeg2+vd4jldpaW4HuP/fMVGYvvzxOa4jrjlluWeXFqyoA==


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/lsp-client/issues/41 by passing a flag `registerProviders` around internally.

This may or may not be a desirable solution, but at least it serves as something to discuss.