### PR TITLE
fix: markdown hover

### DIFF
--- a/src/lsp-conversion.ts
+++ b/src/lsp-conversion.ts
@@ -50,6 +50,9 @@ export function convertHover(sourcegraph: typeof import('sourcegraph'), hover: H
                     if (!content.value) {
                         return ''
                     }
+                    if (content.language === 'markdown') {
+                        return content.value
+                    }
                     return '```' + content.language + '\n' + content.value + '\n```'
                 })
                 .filter(str => !!str.trim())


### PR DESCRIPTION
Previously, markdown content would get wrapped in triple backticks, breaking the syntax highlighting:

![image](https://user-images.githubusercontent.com/1387653/63069237-672ead80-bed3-11e9-9d94-b0c0c8ae6598.png)

![image](https://user-images.githubusercontent.com/1387653/63069247-71e94280-bed3-11e9-9909-a6a6e1bc4ed8.png)
