### PR TITLE
Upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "mocha": "^6.0.0",
     "mock-require": "^3.0.3",
     "nyc": "^13.1.0",
-    "prettier": "^1.16.4",
+    "prettier": "^1.19.1",
     "semantic-release": "^16.0.0-beta.46",
     "sinon": "^7.4.1",
     "ts-node": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "sinon": "^7.4.1",
     "ts-node": "^8.0.2",
     "tslint": "^5.20.1",
-    "typescript": "^3.2.2"
+    "typescript": "^3.7.4"
   },
   "dependencies": {
     "@sourcegraph/vscode-ws-jsonrpc": "^0.0.3-fork",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -58,10 +58,7 @@ export const webSocketTransport = ({
         get closed(): boolean {
             return socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING
         },
-        closeEvent: fromEvent<Event>(socket, 'close').pipe(
-            mapTo(undefined),
-            take(1)
-        ),
+        closeEvent: fromEvent<Event>(socket, 'close').pipe(mapTo(undefined), take(1)),
         sendRequest: async (type, params) => connection.sendRequest(type, params),
         sendNotification: async (type, params) => connection.sendNotification(type, params),
         setRequestHandler: (type, handler) => connection.onRequest(type, handler),

--- a/src/features/feature.ts
+++ b/src/features/feature.ts
@@ -36,6 +36,6 @@ export function scopeDocumentSelectorToRoot(
         .map(filter => ({
             ...filter,
             // TODO filter.pattern needs to be run resolved relative to server root URI before mounting on clientRootUri
-            pattern: new URL(filter.pattern || '**', clientRootUri).href,
+            pattern: new URL(filter.pattern ?? '**', clientRootUri).href,
         }))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,6 +303,7 @@ export async function register({
                 connection.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
                     event: {
                         added: [tempWorkspaceFolder],
+                        removed: [],
                     },
                 })
             }
@@ -313,6 +314,7 @@ export async function register({
                 if (tempWorkspaceFolder) {
                     connection.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
                         event: {
+                            added: [],
                             removed: [tempWorkspaceFolder],
                         },
                     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export async function register({
                 textDocument: {
                     uri: serverTextDocumentUri.href,
                     languageId: textDocument.languageId,
-                    text: textDocument.text || '', // TODO try to fetch contents from somewhere
+                    text: textDocument.text ?? '', // TODO try to fetch contents from somewhere
                     version: 1,
                 },
             }
@@ -209,7 +209,7 @@ export async function register({
             sourcegraph.workspace.openedTextDocuments.subscribe(() => {
                 for (const appWindow of sourcegraph.app.windows) {
                     for (const viewComponent of appWindow.visibleViewComponents) {
-                        const diagnostics = diagnosticsByUri.get(viewComponent.document.uri) || []
+                        const diagnostics = diagnosticsByUri.get(viewComponent.document.uri) ?? []
                         viewComponent.setDecorations(
                             decorationType,
                             diagnostics.map(d => convertDiagnosticToDecoration(sourcegraph, d))

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,16 +287,13 @@ export async function register({
     let withConnection: <R>(workspaceFolder: URL, fn: (connection: LSPConnection) => Promise<R>) => Promise<R>
 
     if (supportsWorkspaceFolders) {
-        const connection = await connect(
-            null,
-            {
-                processId: null,
-                rootUri: null,
-                capabilities: clientCapabilities,
-                workspaceFolders: sourcegraph.workspace.roots.map(toLSPWorkspaceFolder({ clientToServerURI })),
-                initializationOptions,
-            }
-        )
+        const connection = await connect(null, {
+            processId: null,
+            rootUri: null,
+            capabilities: clientCapabilities,
+            workspaceFolders: sourcegraph.workspace.roots.map(toLSPWorkspaceFolder({ clientToServerURI })),
+            initializationOptions,
+        })
         subscriptions.add(connection)
         withConnection = async (workspaceFolder, fn) => {
             let tempWorkspaceFolder: WorkspaceFolder | undefined
@@ -357,16 +354,13 @@ export async function register({
                 return await fn(connection)
             }
             const serverRootUri = clientToServerURI(workspaceFolder)
-            connection = await connect(
-                workspaceFolder,
-                {
-                    processId: null,
-                    rootUri: serverRootUri.href,
-                    capabilities: clientCapabilities,
-                    workspaceFolders: null,
-                    initializationOptions,
-                }
-            )
+            connection = await connect(workspaceFolder, {
+                processId: null,
+                rootUri: serverRootUri.href,
+                capabilities: clientCapabilities,
+                workspaceFolders: null,
+                initializationOptions,
+            })
             subscriptions.add(connection)
             try {
                 return await fn(connection)
@@ -380,16 +374,13 @@ export async function register({
                 const connectionPromise = (async () => {
                     try {
                         const serverRootUri = clientToServerURI(new URL(root.uri.toString()))
-                        const connection = await connect(
-                            new URL(root.uri.toString()),
-                            {
-                                processId: null,
-                                rootUri: serverRootUri.href,
-                                capabilities: clientCapabilities,
-                                workspaceFolders: null,
-                                initializationOptions,
-                            }
-                        )
+                        const connection = await connect(new URL(root.uri.toString()), {
+                            processId: null,
+                            rootUri: serverRootUri.href,
+                            capabilities: clientCapabilities,
+                            workspaceFolders: null,
+                            initializationOptions,
+                        })
                         subscriptions.add(connection)
                         return connection
                     } catch (err) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -54,7 +54,7 @@ export const redact = (message: string): string => message.replace(/(https?:\/\/
  * Logger that formats the logged values and removes any auth info in URLs.
  */
 export class RedactingLogger extends AbstractLogger {
-    constructor(private logger: Logger) {
+    constructor(private readonly logger: Logger) {
         super()
     }
 
@@ -66,7 +66,7 @@ export class RedactingLogger extends AbstractLogger {
 }
 
 export class PrefixedLogger extends AbstractLogger {
-    constructor(private logger: Logger, private prefix: string) {
+    constructor(private readonly logger: Logger, private readonly prefix: string) {
         super()
     }
 

--- a/src/lsp-conversion.ts
+++ b/src/lsp-conversion.ts
@@ -88,7 +88,7 @@ export const convertDiagnosticToDecoration = (
     diagnostic: Diagnostic
 ): sourcegraph.TextDocumentDecoration => ({
     after: {
-        color: DIAGNOSTIC_COLORS[diagnostic.severity || DiagnosticSeverity.Hint],
+        color: DIAGNOSTIC_COLORS[diagnostic.severity ?? DiagnosticSeverity.Hint],
         contentText: diagnostic.message,
     },
     range: convertRange(sourcegraph, diagnostic.range),

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -44,7 +44,10 @@ describe('register()', () => {
             server.initialize,
             sinon.match({
                 rootUri: null,
-                workspaceFolders: [{ name: '', uri: 'git://repo1?rev' }, { name: '', uri: 'git://repo2?rev' }],
+                workspaceFolders: [
+                    { name: '', uri: 'git://repo1?rev' },
+                    { name: '', uri: 'git://repo2?rev' },
+                ],
             })
         )
     })
@@ -109,17 +112,15 @@ describe('register()', () => {
                     },
                 })
             ),
-            'textDocument/references': sinon.spy(
-                (params: ReferenceParams): Location[] => [
-                    {
-                        uri: new URL('bar.ts', repoRoot).href,
-                        range: {
-                            start: { line: 1, character: 2 },
-                            end: { line: 3, character: 4 },
-                        },
+            'textDocument/references': sinon.spy((params: ReferenceParams): Location[] => [
+                {
+                    uri: new URL('bar.ts', repoRoot).href,
+                    range: {
+                        start: { line: 1, character: 2 },
+                        end: { line: 3, character: 4 },
                     },
-                ]
-            ),
+                },
+            ]),
         }
         const createConnection = stubTransport(server)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,7 +1546,7 @@ debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2653,7 +2653,7 @@ import-lazy@^2.1.0:
   resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -3410,11 +3410,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -3423,32 +3418,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -3494,11 +3467,6 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -4786,10 +4754,10 @@ prepend-http@^1.0.1:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4205,7 +4205,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -4220,7 +4219,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.5"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -4239,14 +4237,8 @@ npm@^6.10.3:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -6123,10 +6115,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features